### PR TITLE
Fix: mobile UI polish — notification bell, badges, animations, toasts

### DIFF
--- a/src/Authenticate.tsx
+++ b/src/Authenticate.tsx
@@ -25,7 +25,7 @@ export default function Authenticate() {
     <React.Fragment>
       <div className="px-4">
         <ToastContainer
-          autoClose={3000}
+          autoClose={2000}
           hideProgressBar
           newestOnTop
           closeOnClick

--- a/src/__tests__/components/Header/MobileHeader.test.tsx
+++ b/src/__tests__/components/Header/MobileHeader.test.tsx
@@ -109,9 +109,9 @@ describe('MobileHeader', () => {
     expect(screen.getByTestId('lang-flag')).toBeInTheDocument();
   });
 
-  it('renders notification bell when logged in', () => {
+  it('does not render notification bell (moved to bottom nav)', () => {
     renderComponent('user-1');
-    expect(screen.getByTestId('bell')).toBeInTheDocument();
+    expect(screen.queryByTestId('bell')).not.toBeInTheDocument();
   });
 
   it('renders search bar on home page', () => {

--- a/src/__tests__/components/shared/toast.test.tsx
+++ b/src/__tests__/components/shared/toast.test.tsx
@@ -34,7 +34,7 @@ describe('showToast', () => {
   it('applies success className', () => {
     showToast('success', 'Done');
     const call = (toast as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(call[1].className).toContain('bg-[#3FBA49]');
+    expect(call[1].className).toContain('bg-primary');
   });
 
   it('applies error className', () => {
@@ -43,9 +43,9 @@ describe('showToast', () => {
     expect(call[1].className).toContain('bg-[#EA244E]');
   });
 
-  it('sets width to 360px', () => {
+  it('includes font-poppins styling', () => {
     showToast('success', 'Test');
     const call = (toast as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
-    expect(call[1].style).toEqual({ width: '360px' });
+    expect(call[1].className).toContain('font-poppins');
   });
 });

--- a/src/__tests__/pages/books/Filter.test.tsx
+++ b/src/__tests__/pages/books/Filter.test.tsx
@@ -94,11 +94,6 @@ describe('Filter', () => {
       </Provider>,
     );
 
-  it('renders category button', () => {
-    renderComponent();
-    expect(screen.getByText('books.category')).toBeInTheDocument();
-  });
-
   it('renders add book button', () => {
     renderComponent();
     expect(screen.getByText(/books.addBook/)).toBeInTheDocument();
@@ -114,20 +109,9 @@ describe('Filter', () => {
     expect(screen.getByText(/books.sort/)).toBeInTheDocument();
   });
 
-  it('renders map button', () => {
-    renderComponent();
-    expect(screen.getByText('books.map')).toBeInTheDocument();
-  });
-
   it('renders category slider', () => {
     renderComponent();
     expect(screen.getByTestId('category-slider')).toBeInTheDocument();
-  });
-
-  it('navigates to map on map button click', () => {
-    renderComponent();
-    fireEvent.click(screen.getByText('books.map'));
-    expect(mockNavigate).toHaveBeenCalledWith('/map');
   });
 
   it('navigates to profile when logged in user clicks Add Book', () => {

--- a/src/components/Footer/_components/BottomNav.tsx
+++ b/src/components/Footer/_components/BottomNav.tsx
@@ -3,12 +3,14 @@ import { useLocation } from 'react-router-dom';
 import { menu } from '../../../data/menu';
 import { selectTotalUnreadCount } from '../../../redux/feature/messages/messagesSlice';
 import { useAppSelector } from '../../../redux/hooks';
+import NotificationBell from '../../Header/_components/NotificationBell';
 import BottomNavItem from './BottomNavItem';
 
 export default function BottomNav() {
   const { t } = useTranslation();
   const location = useLocation();
   const totalUnreadCount = useAppSelector(selectTotalUnreadCount);
+  const { userInformation } = useAppSelector((state) => state.auth);
   const pathname = location.pathname;
   const ignorePath: string[] = [`/book-details/${pathname?.split('/').reverse()[0]}`];
   const isFooterBarShow = ignorePath.includes(pathname);
@@ -38,6 +40,7 @@ export default function BottomNav() {
               </div>
             );
           })}
+        {userInformation?.id && <NotificationBell variant="bottom-nav" />}
       </div>
     </div>
   );

--- a/src/components/Footer/_components/BottomNavItem.tsx
+++ b/src/components/Footer/_components/BottomNavItem.tsx
@@ -27,7 +27,7 @@ export default function BottomNavItem({
       }}
     >
       {showBadge && (
-        <span className="absolute top-0 right-2 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center font-medium">
+        <span className="absolute -top-1 right-1 bg-red text-white text-[10px] font-semibold font-poppins rounded-full min-w-[18px] h-[18px] flex items-center justify-center px-1 leading-none shadow-sm">
           {badgeCount > 9 ? '9+' : badgeCount}
         </span>
       )}

--- a/src/components/Header/_components/MobileHeader.tsx
+++ b/src/components/Header/_components/MobileHeader.tsx
@@ -14,14 +14,12 @@ import SearchBar from '../../shared/SearchBar';
 import HeaderUserProfile from './HeaderUserProfile';
 import LanguageFlagButton from './LanguageFlagButton';
 import LanguageMenuDropdown from './LanguageMenuDropdown';
-import NotificationBell from './NotificationBell';
 
 export default function MobileHeader() {
   const dispatch = useAppDispatch();
   const location = useLocation();
   const { scrolled } = useScroll();
   const { clicked, setClicked, reference } = useMouseClick();
-  const { userInformation } = useAppSelector((state) => state.auth);
   const { searchToggle } = useAppSelector((state) => state.open);
   const pathname = location.pathname;
   const shouldCollapse = scrolled || searchToggle;
@@ -85,7 +83,6 @@ export default function MobileHeader() {
               >
                 <LanguageFlagButton clicked={clicked} setClicked={setClicked} />
                 {clicked && <LanguageMenuDropdown />}
-                {userInformation.id && <NotificationBell />}
                 <HeaderUserProfile />
               </div>
             </div>

--- a/src/components/Header/_components/NotificationBell.tsx
+++ b/src/components/Header/_components/NotificationBell.tsx
@@ -18,13 +18,14 @@ import NotificationItem from './NotificationItem';
 
 interface NotificationBellProps {
   className?: string;
+  variant?: 'header' | 'bottom-nav';
 }
 
 /**
  * NotificationBell component displays a notification icon with badge and dropdown panel
  * Integrates with WebSocket notifications and Redux state management
  */
-const NotificationBell: React.FC<NotificationBellProps> = ({ className }) => {
+const NotificationBell: React.FC<NotificationBellProps> = ({ className, variant = 'header' }) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const notifications = useAppSelector(selectSortedNotifications);
@@ -79,30 +80,69 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ className }) => {
     }
   }, [isNotificationPanelOpen, handleKeyDown]);
 
+  const isBottomNav = variant === 'bottom-nav';
+
   return (
     <div ref={reference} className={cn('relative', className)}>
       {/* Bell Icon Button */}
       <button
         onClick={handleBellClick}
-        className="relative p-2 hover:bg-light rounded-full border border-platinumMix transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+        className={cn(
+          'relative focus:outline-none transition-colors',
+          isBottomNav
+            ? 'p-0 flex flex-col items-center gap-1'
+            : 'p-2 hover:bg-light rounded-full border border-platinumMix focus:ring-2 focus:ring-primary focus:ring-offset-2',
+        )}
         aria-label={`Notifications, ${unreadCount} unread`}
         aria-expanded={isNotificationPanelOpen}
         aria-haspopup="true"
       >
-        <img src={notificationIcon} alt="Notifications" className="w-6 h-6" />
+        <div className="relative h-7 flex items-center justify-center">
+          <img
+            src={notificationIcon}
+            alt="Notifications"
+            className={isBottomNav ? 'w-5 h-5' : 'w-6 h-6'}
+            style={
+              isBottomNav
+                ? {
+                    filter: isNotificationPanelOpen
+                      ? 'brightness(0) saturate(100%) invert(43%) sepia(98%) saturate(2375%) hue-rotate(185deg) brightness(93%) contrast(98%)'
+                      : 'none',
+                    transition: 'filter 0.2s ease-in-out',
+                  }
+                : undefined
+            }
+          />
 
-        {/* Unread Count Badge */}
-        {unreadCount > 0 && (
-          <span
-            className="absolute -top-1 -right-1 bg-red text-white text-xs font-semibold font-poppins rounded-full min-w-[20px] h-5 flex items-center justify-center px-1.5"
-            aria-label={`${unreadCount} unread notifications`}
+          {/* Unread Count Badge */}
+          {unreadCount > 0 && (
+            <span
+              className={cn(
+                'absolute flex items-center justify-center rounded-full font-semibold font-poppins leading-none shadow-sm',
+                isBottomNav
+                  ? '-top-2 -right-3 bg-red text-white text-[10px] min-w-[18px] h-[18px] px-1'
+                  : '-top-3 -right-3 bg-red text-white text-xs min-w-[20px] h-5 px-1.5',
+              )}
+              aria-label={`${unreadCount} unread notifications`}
+            >
+              {unreadCount > 99 ? '99+' : unreadCount}
+            </span>
+          )}
+        </div>
+
+        {/* Bottom nav label */}
+        {isBottomNav && (
+          <p
+            className={`leading-none text-xs font-poppins ${
+              isNotificationPanelOpen ? 'font-medium text-primary' : 'font-light text-grayDark'
+            }`}
           >
-            {unreadCount > 99 ? '99+' : unreadCount}
-          </span>
+            {t('notification.alerts')}
+          </p>
         )}
 
         {/* Connection Status Indicator (only shown on error) */}
-        {wsConnectionStatus === 'error' && (
+        {!isBottomNav && wsConnectionStatus === 'error' && (
           <span
             className="absolute bottom-0 right-0 w-3 h-3 bg-yellow border-2 border-white rounded-full"
             aria-label="Connection error"
@@ -114,7 +154,12 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ className }) => {
       {/* Notification Dropdown Panel */}
       {isNotificationPanelOpen && (
         <div
-          className="absolute right-0 mt-2 w-80 sm:w-96 bg-white rounded-lg shadow-lg border border-platinum overflow-hidden z-50 animate-fadeIn"
+          className={cn(
+            'absolute w-80 sm:w-96 bg-white rounded-lg shadow-lg border border-platinum overflow-hidden z-50',
+            isBottomNav
+              ? 'bottom-full mb-2 right-0 animate-slideUp'
+              : 'right-0 mt-2 animate-fadeIn',
+          )}
           role="menu"
           aria-label="Notification list"
         >
@@ -174,6 +219,7 @@ const NotificationBell: React.FC<NotificationBellProps> = ({ className }) => {
 
 NotificationBell.propTypes = {
   className: PropTypes.string,
+  variant: PropTypes.oneOf(['header', 'bottom-nav']),
 };
 
 export default NotificationBell;

--- a/src/components/shared/toast.tsx
+++ b/src/components/shared/toast.tsx
@@ -7,12 +7,11 @@ type ToastType = 'success' | 'error';
 export const showToast = (type: ToastType, message: string) => {
   const baseOptions: ToastOptions = {
     position: 'bottom-left',
-    style: { width: '360px' },
     closeButton: <IoClose className="text-white absolute right-1" />,
     className:
       type === 'success'
-        ? 'bg-[#3FBA49] text-white rounded-md px-4 py-3'
-        : 'bg-[#EA244E] text-white rounded-md px-4 py-3 ',
+        ? 'bg-primary text-white rounded-md px-4 py-3 font-poppins text-sm'
+        : 'bg-[#EA244E] text-white rounded-md px-4 py-3 font-poppins text-sm',
     icon: type === 'success' ? <FaCheckCircle size={18} /> : <IoCloseCircle size={18} />,
   };
 

--- a/src/locales/en.properties
+++ b/src/locales/en.properties
@@ -548,3 +548,4 @@ changePassword.success=Password changed successfully.
 changePassword.failed=Failed to change password.
 changePassword.mismatch=Passwords do not match.
 notification.daysAgo={{count}} days ago
+notification.alerts=Alerts

--- a/src/locales/fi.properties
+++ b/src/locales/fi.properties
@@ -513,6 +513,7 @@ notification.hourAgo={{count}} tunti sitten
 notification.hoursAgo={{count}} tuntia sitten
 notification.dayAgo={{count}} päivä sitten
 notification.daysAgo={{count}} päivää sitten
+notification.alerts=Hälytykset
 bookmark.added=Kirja lisätty kirjanmerkkeihin!
 bookmark.failed=Kirjanmerkin lisääminen epäonnistui.
 changePassword.title=Vaihda salasana

--- a/src/locales/sv.properties
+++ b/src/locales/sv.properties
@@ -513,6 +513,7 @@ notification.hourAgo={{count}} timme sedan
 notification.hoursAgo={{count}} timmar sedan
 notification.dayAgo={{count}} dag sedan
 notification.daysAgo={{count}} dagar sedan
+notification.alerts=Aviseringar
 bookmark.added=Boken bokmärkt!
 bookmark.failed=Det gick inte att bokmärka boken.
 changePassword.title=Ändra lösenord

--- a/src/pages/books/_components/Filter.tsx
+++ b/src/pages/books/_components/Filter.tsx
@@ -5,9 +5,7 @@ import { FiPlus } from 'react-icons/fi';
 import { MdKeyboardArrowDown } from 'react-icons/md';
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import CategoryIcon from '../../../assets/categoryIcon.svg';
 import filtergrayIcon from '../../../assets/filtergray.svg';
-import mapIcon from '../../../assets/uiw_map.svg';
 import sortByIcon from '../../../assets/sortBy.svg';
 import Button from '../../../components/shared/Button';
 import Image from '../../../components/shared/Image';
@@ -106,12 +104,6 @@ export default function Filter() {
         >
           <div className="flex items-center gap-2  ">
             <Button
-              onClick={() => isFilterOrCategoryOrSortByFn(FilterItemEnum.CATEGORY)}
-              className=" border border-platinum bg-white flex items-center gap-2 text-blackOlive px-4 py-2 rounded-lg font-poppins text-sm font-medium"
-            >
-              <Image src={CategoryIcon} alt="category" /> {t('books.category')}
-            </Button>
-            <Button
               className=" bg-primary flex items-center gap-2 text-white px-4 py-2 rounded-lg font-poppins text-sm font-medium"
               onClick={() => {
                 if (userInformation.id) {
@@ -130,12 +122,6 @@ export default function Filter() {
           </div>
 
           <div className="flex items-center gap-2 ">
-            <Button
-              onClick={() => navigate('/map')}
-              className=" border border-platinum bg-white flex items-center gap-2 text-blackOlive px-4 py-2 rounded-lg font-poppins text-sm font-medium"
-            >
-              <Image src={mapIcon} alt="map" className="w-[18px] h-[18px]" /> {t('books.map')}
-            </Button>
             <Button
               onClick={() => isFilterOrCategoryOrSortByFn(FilterItemEnum.FILTER)}
               className=" border border-platinum bg-white flex items-center gap-2 text-blackOlive px-4 py-2 rounded-lg font-poppins text-sm font-medium"

--- a/src/pages/books/index.tsx
+++ b/src/pages/books/index.tsx
@@ -3,18 +3,9 @@ import { useTranslation } from 'react-i18next';
 import BookCard from '../../components/shared/BookCard';
 import BookSkeleton from '../../components/shared/skeleton/BookSkeleton';
 import PageTitle from '../../components/shared/PageTitle';
-import {
-  useGetAllBooksQuery,
-  useGetBooksNearLocationQuery,
-} from '../../redux/feature/book/bookApi';
-import {
-  clearAllFilters,
-  setFilterOpen,
-  setIsCategoryOrFilterOrSortBy,
-  setPageNumber,
-} from '../../redux/feature/filter/filterSlice';
+import { useGetAllBooksQuery } from '../../redux/feature/book/bookApi';
+import { clearAllFilters, setPageNumber } from '../../redux/feature/filter/filterSlice';
 import { useAppDispatch, useAppSelector } from '../../redux/hooks';
-import { FilterItemEnum } from '../../utility/enum';
 import Filter from './_components/Filter';
 import HeroSection from './_components/Herosection';
 import NoBooksAvailable from './_components/NoBooksAvailable';
@@ -30,66 +21,17 @@ export default function Books() {
   } = useAppSelector((state) => state.auth);
   const dispatch = useAppDispatch();
 
-  // =========== NEAR ME STATE ===========
-  const [nearMe, setNearMe] = useState(false);
-  const [userCoords, setUserCoords] = useState<{ latitude: number; longitude: number } | null>(
-    null,
-  );
-
-  const handleNearMe = () => {
-    if (nearMe) {
-      setNearMe(false);
-      setUserCoords(null);
-      dispatch(setPageNumber(0));
-      return;
-    }
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(
-        (position) => {
-          setUserCoords({
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-          });
-          setNearMe(true);
-          dispatch(setPageNumber(0));
-        },
-        () => {
-          setNearMe(false);
-        },
-      );
-    }
-  };
-
   // Fetch books
   const { data, isError, isLoading, isFetching } = useGetAllBooksQuery(
     { filter, notOwnerId: id },
-    { refetchOnMountOrArgChange: false, skip: nearMe },
+    { refetchOnMountOrArgChange: false },
   );
-
-  const {
-    data: nearData,
-    isError: nearError,
-    isLoading: nearLoading,
-    isFetching: nearFetching,
-  } = useGetBooksNearLocationQuery(
-    {
-      latitude: userCoords?.latitude ?? 0,
-      longitude: userCoords?.longitude ?? 0,
-      page: filter.pageNumber,
-    },
-    { skip: !nearMe || !userCoords },
-  );
-
-  const activeData = nearMe ? nearData : data;
-  const activeIsError = nearMe ? nearError : isError;
-  const activeIsFetching = nearMe ? nearFetching : isFetching;
-  const activeIsLoading = nearMe ? nearLoading : isLoading;
 
   // Merge & paginate data
   useEffect(() => {
-    if (activeData?._embedded?.books?.length > 0) {
+    if (data?._embedded?.books?.length > 0) {
       setBooks((prevBooks) => {
-        const newBooks = activeData._embedded.books;
+        const newBooks = data._embedded.books;
         const allBooks = filter.pageNumber === 0 ? newBooks : [...prevBooks, ...newBooks];
         const uniqueBooks = Array.from(
           new Map<string, IBook>(allBooks.map((book: IBook) => [book.id, book])).values(),
@@ -100,10 +42,10 @@ export default function Books() {
     }
 
     // If no books returned for first page, reset state
-    if (activeData && (!activeData._embedded?.books || activeData._embedded.books.length === 0)) {
+    if (data && (!data._embedded?.books || data._embedded.books.length === 0)) {
       if (filter.pageNumber === 0) setBooks([]);
     }
-  }, [activeData, filter.pageNumber]);
+  }, [data, filter.pageNumber]);
 
   // Infinite scroll: detect filter changes
   const prevFilterRef = useRef({
@@ -154,34 +96,32 @@ export default function Books() {
     return () => {
       dispatch(setPageNumber(0));
       dispatch(clearAllFilters());
-      setNearMe(false);
-      setUserCoords(null);
     };
   }, [dispatch]);
 
   // Intersection Observer for infinite scroll
   const lastBookRef = useCallback(
     (node: HTMLDivElement) => {
-      if (activeIsFetching) return;
+      if (isFetching) return;
 
       if (observer.current) observer.current.disconnect();
       observer.current = new IntersectionObserver((entries) => {
         if (
           entries[0].isIntersecting &&
-          activeData != null &&
-          filter.pageNumber + 1 < activeData.page.totalPages
+          data != null &&
+          filter.pageNumber + 1 < data.page.totalPages
         ) {
           dispatch(setPageNumber(filter.pageNumber + 1));
         }
       });
       if (node) observer.current.observe(node);
     },
-    [activeIsFetching, activeData, filter.pageNumber, dispatch],
+    [isFetching, data, filter.pageNumber, dispatch],
   );
 
-  const isInitialLoading = activeIsFetching || activeIsLoading;
+  const isInitialLoading = isFetching || isLoading;
 
-  if (activeIsError)
+  if (isError)
     return (
       <div className="container min-h-[60vh] flex items-center justify-center">
         <div className="text-center">
@@ -202,49 +142,6 @@ export default function Books() {
       <PageTitle title={t('books')} />
       <div className="container min-h-[80vh] pb-24 lg:py-6">
         <HeroSection />
-        <div className="flex items-center gap-2 mb-4 lg:hidden">
-          <button
-            type="button"
-            onClick={handleNearMe}
-            className={`flex-1 border flex items-center justify-center gap-2 px-3 py-2 rounded-lg font-poppins text-xs font-medium ${
-              nearMe
-                ? 'bg-primary text-white border-primary'
-                : 'border-platinum bg-white text-blackOlive'
-            }`}
-          >
-            {t('books.nearMe')}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              dispatch(setIsCategoryOrFilterOrSortBy(FilterItemEnum.FILTER));
-              dispatch(setFilterOpen(true));
-            }}
-            className="flex-1 border border-platinum bg-white flex items-center justify-center gap-2 text-blackOlive px-3 py-2 rounded-lg font-poppins text-xs font-medium"
-          >
-            {t('books.filter')}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              dispatch(setIsCategoryOrFilterOrSortBy(FilterItemEnum.SORTBY));
-              dispatch(setFilterOpen(true));
-            }}
-            className="flex-1 border border-platinum bg-white flex items-center justify-center gap-2 text-blackOlive px-3 py-2 rounded-lg font-poppins text-xs font-medium"
-          >
-            {t('books.sort')}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              dispatch(setIsCategoryOrFilterOrSortBy(FilterItemEnum.CATEGORY));
-              dispatch(setFilterOpen(true));
-            }}
-            className="flex-1 border border-platinum bg-white flex items-center justify-center gap-2 text-blackOlive px-3 py-2 rounded-lg font-poppins text-xs font-medium"
-          >
-            {t('books.category')}
-          </button>
-        </div>
         <div className="relative hidden lg:block">
           <Filter />
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -86,17 +86,22 @@ export default {
       },
       dropShadow: {},
       animation: {
-        fadeIn: 'fadeIn 0.5s ease-out',
-        fadeOut: 'fadeOut 0.5s ease-out',
+        fadeIn: 'fadeIn 0.2s cubic-bezier(0.16, 1, 0.3, 1)',
+        fadeOut: 'fadeOut 0.2s cubic-bezier(0.16, 1, 0.3, 1)',
+        slideUp: 'slideUp 0.2s cubic-bezier(0.16, 1, 0.3, 1)',
       },
       keyframes: {
         fadeIn: {
-          '0%': { opacity: 0, transform: 'translateY(-20px)' },
+          '0%': { opacity: 0, transform: 'translateY(-8px)' },
           '100%': { opacity: 1, transform: 'translateY(0)' },
         },
         fadeOut: {
           '0%': { opacity: 1, transform: 'translateY(0)' },
-          '100%': { opacity: 0, transform: 'translateY(-20px)' },
+          '100%': { opacity: 0, transform: 'translateY(-8px)' },
+        },
+        slideUp: {
+          '0%': { opacity: 0, transform: 'translateY(8px)' },
+          '100%': { opacity: 1, transform: 'translateY(0)' },
         },
       },
     },


### PR DESCRIPTION
## Summary
- **Notification bell**: moved from mobile top header to bottom navbar (with upward-opening panel, unread badge)
- **Unread message badge**: fixed invisible badge (`bg-red-500` → `bg-red` to match project Tailwind config)
- **Animations**: smoother Material-style deceleration curves (`0.2s`, `8px` travel), added `slideUp` for bottom-nav panel
- **Toasts**: success color changed to project blue (`#3879E9`), duration reduced to 2s, removed fixed width for mobile responsiveness
- **Books page**: removed all 4 mobile filter buttons (Near Me, Filter, Sort, Category) after banner; removed desktop Category and Map buttons

## Test plan
- [ ] Mobile: notification bell visible in bottom navbar with unread badge, panel opens upward
- [ ] Mobile: unread message count badge visible (red pill) on Messages icon
- [ ] Desktop: notification bell still in top header (unchanged)
- [ ] Notification panel opens/closes smoothly (no jitter)
- [ ] Toasts: blue for success, red for error, 2s auto-close, responsive on mobile
- [ ] Books page mobile: no filter buttons after banner
- [ ] Books page desktop: no Category or Map buttons in filter bar