### PR TITLE
Fix: UI polish — optimistic bookmarks, filter alignment, smooth scroll

### DIFF
--- a/src/__tests__/components/Header/BookFilter/FilterBySort.test.tsx
+++ b/src/__tests__/components/Header/BookFilter/FilterBySort.test.tsx
@@ -23,10 +23,6 @@ vi.mock('../../../../components/shared/Button', () => ({
   ),
 }));
 
-vi.mock('../../../../components/shared/Line', () => ({
-  default: () => <hr />,
-}));
-
 function Wrapper({ children }: { children: React.ReactNode }) {
   const methods = useForm({ defaultValues: { sortBy: [] } });
   return <FormProvider {...methods}>{children}</FormProvider>;
@@ -65,7 +61,7 @@ describe('FilterBySort', () => {
 
     const titleOption = screen.getByText('filter.sortTitleAZ').closest('button')!;
     fireEvent.click(titleOption);
-    expect(titleOption).toHaveClass('bg-primary');
+    expect(titleOption).toHaveClass('bg-AntiFlashWhite');
   });
 
   it('deselects a sort option on second click', () => {
@@ -77,13 +73,13 @@ describe('FilterBySort', () => {
 
     const titleOption = screen.getByText('filter.sortTitleAZ').closest('button')!;
     fireEvent.click(titleOption);
-    expect(titleOption).toHaveClass('bg-primary');
+    expect(titleOption).toHaveClass('bg-AntiFlashWhite');
 
     fireEvent.click(titleOption);
-    expect(titleOption).not.toHaveClass('bg-primary');
+    expect(titleOption).not.toHaveClass('bg-AntiFlashWhite');
   });
 
-  it('allows multiple selections', () => {
+  it('allows only one selection at a time', () => {
     render(
       <Wrapper>
         <FilterBySort />
@@ -93,7 +89,27 @@ describe('FilterBySort', () => {
     fireEvent.click(screen.getByText('filter.sortTitleAZ').closest('button')!);
     fireEvent.click(screen.getByText('filter.sortAuthorAZ').closest('button')!);
 
-    expect(screen.getByText('filter.sortTitleAZ').closest('button')).toHaveClass('bg-primary');
-    expect(screen.getByText('filter.sortAuthorAZ').closest('button')).toHaveClass('bg-primary');
+    expect(screen.getByText('filter.sortTitleAZ').closest('button')).not.toHaveClass(
+      'bg-AntiFlashWhite',
+    );
+    expect(screen.getByText('filter.sortAuthorAZ').closest('button')).toHaveClass(
+      'bg-AntiFlashWhite',
+    );
+  });
+
+  it('collapses and expands the sort options', () => {
+    render(
+      <Wrapper>
+        <FilterBySort />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText('filter.sortTitleAZ')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('filter.sortBy').closest('button')!);
+    expect(screen.queryByText('filter.sortTitleAZ')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('filter.sortBy').closest('button')!);
+    expect(screen.getByText('filter.sortTitleAZ')).toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/Header/BookFilter/genreIcons.test.ts
+++ b/src/__tests__/components/Header/BookFilter/genreIcons.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 
-import { getGenreIcon, defaultGenreIcon } from '../../../../components/Header/_components/BookFilter/genreIcons';
+import {
+  getGenreIcon,
+  defaultGenreIcon,
+} from '../../../../components/Header/_components/BookFilter/genreIcons';
 
 describe('getGenreIcon', () => {
   it('returns an icon for Fiction', () => {

--- a/src/__tests__/pages/books/NoBooksAvailable.test.tsx
+++ b/src/__tests__/pages/books/NoBooksAvailable.test.tsx
@@ -6,10 +6,6 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('../../../components/shared/Image', () => ({
-  default: ({ alt }: { alt: string }) => <img alt={alt} />,
-}));
-
 describe('NoBooksAvailable', () => {
   it('renders the no books heading', () => {
     render(<NoBooksAvailable />);
@@ -19,10 +15,5 @@ describe('NoBooksAvailable', () => {
   it('renders the filter message', () => {
     render(<NoBooksAvailable />);
     expect(screen.getByText('books.noBooksDesc')).toBeInTheDocument();
-  });
-
-  it('renders the not found image', () => {
-    render(<NoBooksAvailable />);
-    expect(screen.getByAltText('not found')).toBeInTheDocument();
   });
 });

--- a/src/components/Header/_components/BookFilter/FilterByCondition.tsx
+++ b/src/components/Header/_components/BookFilter/FilterByCondition.tsx
@@ -64,11 +64,11 @@ export default function FilterByCondition() {
                         {isChecked ? (
                           <Image
                             src={tickmarkIcon}
-                            alt="tickmarkIcon icon"
-                            className="h-4 w-full"
+                            alt="selected"
+                            className="h-4 w-4 flex-shrink-0"
                           />
                         ) : (
-                          <Image src={plusIcon} alt="plus icon" className="h-4 w-full" />
+                          <Image src={plusIcon} alt="add" className="h-4 w-4 flex-shrink-0" />
                         )}
                       </Button>
                     );

--- a/src/components/Header/_components/BookFilter/FilterByGenre.tsx
+++ b/src/components/Header/_components/BookFilter/FilterByGenre.tsx
@@ -14,6 +14,14 @@ import GenreSkelton from './GenreSkelton';
 type TChildGenre = { id: string; name: string };
 type TParentGenre = { id: string; name: string; childGenres: TChildGenre[] };
 
+function SelectIcon({ isChecked }: { isChecked: boolean }) {
+  return isChecked ? (
+    <Image src={tickmarkIcon} alt="selected" className="h-4 w-4 flex-shrink-0" />
+  ) : (
+    <Image src={plusIcon} alt="add" className="h-4 w-4 flex-shrink-0" />
+  );
+}
+
 export default function FilterByGenre() {
   const { t } = useTranslation();
   const { control } = useFormContext();
@@ -32,7 +40,7 @@ export default function FilterByGenre() {
     : [];
 
   return (
-    <div className="px-4  ">
+    <div className="px-4">
       {isGenreLoading ? (
         <div className="flex flex-col gap-2">
           {Array.from({ length: 6 }, (_, index) => (
@@ -46,7 +54,7 @@ export default function FilterByGenre() {
           render={({ field }) => (
             <div>
               <span className="font-poppins font-normal text-sm">{t('editProfile.genre')}</span>
-              <div className="pl-2">
+              <div className="mt-2 space-y-0.5">
                 {genres.map((parent) => {
                   const hasChildren = parent.childGenres?.length > 0;
                   const Icon = getGenreIcon(parent.name);
@@ -54,56 +62,47 @@ export default function FilterByGenre() {
 
                   if (!hasChildren) {
                     return (
-                      <div key={parent.id} className="py-2">
-                        <Button
-                          type="button"
-                          onClick={() => {
-                            if (isParentSelected) {
-                              field.onChange(field.value.filter((v: string) => v !== parent.name));
-                            } else {
-                              field.onChange([...field.value, parent.name]);
-                            }
-                          }}
-                          className={`flex items-center justify-between w-full ${isParentSelected ? 'bg-AntiFlashWhite' : ''} px-2.5 rounded-sm`}
-                        >
-                          <div className="flex items-center gap-2">
-                            <Icon
-                              className="w-5 h-5"
-                              style={{
-                                color: isParentSelected ? '#3879E9' : '#808080',
-                                transition: 'color 0.2s ease-in-out',
-                              }}
-                            />
-                            <span
-                              className={`${isParentSelected ? 'text-primary' : 'text-blackOlive'} font-poppins font-normal text-sm`}
-                            >
-                              {parent.name}
-                            </span>
-                          </div>
-                          {isParentSelected ? (
-                            <Image
-                              src={tickmarkIcon}
-                              alt="tickmarkIcon icon"
-                              className="h-4 w-full"
-                            />
-                          ) : (
-                            <Image src={plusIcon} alt="plus icon" className="h-4 w-full" />
-                          )}
-                        </Button>
-                      </div>
+                      <Button
+                        key={parent.id}
+                        type="button"
+                        onClick={() => {
+                          if (isParentSelected) {
+                            field.onChange(field.value.filter((v: string) => v !== parent.name));
+                          } else {
+                            field.onChange([...field.value, parent.name]);
+                          }
+                        }}
+                        className={`flex items-center justify-between w-full h-[28px] ${isParentSelected ? 'bg-AntiFlashWhite' : ''} px-2.5 rounded-sm`}
+                      >
+                        <div className="flex items-center gap-2">
+                          <Icon
+                            className="w-5 h-5 flex-shrink-0"
+                            style={{
+                              color: isParentSelected ? '#3879E9' : '#808080',
+                              transition: 'color 0.2s ease-in-out',
+                            }}
+                          />
+                          <span
+                            className={`${isParentSelected ? 'text-primary' : 'text-blackOlive'} font-poppins font-normal text-sm`}
+                          >
+                            {parent.name}
+                          </span>
+                        </div>
+                        <SelectIcon isChecked={isParentSelected} />
+                      </Button>
                     );
                   }
 
                   return (
-                    <div key={parent.id} className="py-2">
+                    <div key={parent.id}>
                       <Button
                         type="button"
                         onClick={() => toggleExpand(parent.id)}
-                        className="flex items-center justify-between w-full"
+                        className="flex items-center justify-between w-full h-[28px] px-2.5 rounded-sm"
                       >
                         <div className="flex items-center gap-2">
                           <Icon
-                            className="w-5 h-5"
+                            className="w-5 h-5 flex-shrink-0"
                             style={{
                               color: expanded[parent.id] ? '#3879E9' : '#808080',
                               transition: 'color 0.2s ease-in-out',
@@ -115,11 +114,13 @@ export default function FilterByGenre() {
                             {parent.name}
                           </span>
                         </div>
-                        <span>{expanded[parent.id] ? <IoIosArrowUp /> : <IoIosArrowDown />}</span>
+                        <span className="w-4 flex-shrink-0 flex items-center justify-center">
+                          {expanded[parent.id] ? <IoIosArrowUp /> : <IoIosArrowDown />}
+                        </span>
                       </Button>
 
                       {expanded[parent.id] && (
-                        <div className="ml-3 mt-2 space-y-2 border-l border-platinumMix pl-4">
+                        <div className="ml-7 mt-1 space-y-0.5 border-l border-platinumMix pl-4">
                           {parent.childGenres.map((child) => {
                             const isChecked = field.value.includes(child.name);
                             return (
@@ -135,18 +136,12 @@ export default function FilterByGenre() {
                                     field.onChange([...field.value, child.name]);
                                   }
                                 }}
-                                className={`flex items-center justify-between gap-2 cursor-pointer w-full text-blackOlive font-poppins font-normal h-[28px] ${isChecked ? 'bg-AntiFlashWhite' : ''} px-2.5 rounded-sm`}
+                                className={`flex items-center justify-between w-full h-[28px] ${isChecked ? 'bg-AntiFlashWhite' : ''} px-2.5 rounded-sm`}
                               >
-                                <span className="text-sm">{child.name}</span>
-                                {isChecked ? (
-                                  <Image
-                                    src={tickmarkIcon}
-                                    alt="tickmarkIcon icon"
-                                    className="h-4 w-full"
-                                  />
-                                ) : (
-                                  <Image src={plusIcon} alt="plus icon" className="h-4 w-full" />
-                                )}
+                                <span className="text-blackOlive font-poppins font-normal text-sm">
+                                  {child.name}
+                                </span>
+                                <SelectIcon isChecked={isChecked} />
                               </Button>
                             );
                           })}

--- a/src/components/Header/_components/BookFilter/FilterByLanguage.tsx
+++ b/src/components/Header/_components/BookFilter/FilterByLanguage.tsx
@@ -62,11 +62,11 @@ export default function FilterByLanguage() {
                         {isChecked ? (
                           <Image
                             src={tickmarkIcon}
-                            alt="tickmarkIcon icon"
-                            className="h-4 w-full"
+                            alt="selected"
+                            className="h-4 w-4 flex-shrink-0"
                           />
                         ) : (
-                          <Image src={plusIcon} alt="plus icon" className="h-4 w-full" />
+                          <Image src={plusIcon} alt="add" className="h-4 w-4 flex-shrink-0" />
                         )}
                       </Button>
                     );

--- a/src/components/Header/_components/BookFilter/FilterBySort.tsx
+++ b/src/components/Header/_components/BookFilter/FilterBySort.tsx
@@ -1,8 +1,9 @@
+import { useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
+import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io';
 import { SortByEnum } from '../../../../utility/enum';
 import Button from '../../../shared/Button';
-import Line from '../../../shared/Line';
 
 const sortLabelKeys: Record<SortByEnum, string> = {
   [SortByEnum.title]: 'filter.sortTitleAZ',
@@ -14,18 +15,26 @@ const sortLabelKeys: Record<SortByEnum, string> = {
 export default function FilterBySort() {
   const { t } = useTranslation();
   const { control } = useFormContext();
+  const [expanded, setExpanded] = useState(true);
 
   return (
-    <div>
+    <div className="px-4">
       <Controller
         name="sortBy"
         control={control}
         render={({ field }) => (
           <div className="py-2">
-            <div className="mt-2 space-y-0.5">
-              <span className="font-poppins font-normal text-sm px-4">{t('filter.sortBy')}</span>
-              <Line className="mt-6 mb-10" />
-              <div>
+            <Button
+              type="button"
+              onClick={() => setExpanded((prev) => !prev)}
+              className="flex items-center justify-between w-full pr-2"
+            >
+              <span className="font-poppins font-normal text-sm">{t('filter.sortBy')}</span>
+              <span>{expanded ? <IoIosArrowUp /> : <IoIosArrowDown />}</span>
+            </Button>
+
+            {expanded && (
+              <div className="mt-2 space-y-2">
                 {Object.entries(sortLabelKeys).map(([value, labelKey]) => {
                   const isChecked = field.value?.includes(value);
                   return (
@@ -33,22 +42,21 @@ export default function FilterBySort() {
                       key={value}
                       type="button"
                       onClick={() => {
-                        if (isChecked) {
-                          field.onChange(field.value.filter((v: string) => v !== value));
-                        } else {
-                          field.onChange([...(field.value || []), value]);
-                        }
+                        field.onChange(isChecked ? [] : [value]);
                       }}
-                      className={`flex items-center justify-between gap-1 cursor-pointer w-full text-blackOlive font-poppins font-normal h-8 text-sm ${
-                        isChecked ? 'bg-primary text-white font-medium' : ''
-                      } px-4`}
+                      className={`flex items-center justify-between gap-2 cursor-pointer w-full text-blackOlive font-poppins font-normal h-[28px] ${isChecked ? 'bg-AntiFlashWhite' : ''} px-2.5 rounded-sm`}
                     >
-                      <span className="pl-2">{t(labelKey)}</span>
+                      <span className="text-sm">{t(labelKey)}</span>
+                      <span
+                        className={`w-4 h-4 rounded-full border-2 flex items-center justify-center flex-shrink-0 ${isChecked ? 'border-primary' : 'border-grayDark'}`}
+                      >
+                        {isChecked && <span className="w-2 h-2 rounded-full bg-primary" />}
+                      </span>
                     </Button>
                   );
                 })}
               </div>
-            </div>
+            )}
           </div>
         )}
       />

--- a/src/components/shared/BookCard.tsx
+++ b/src/components/shared/BookCard.tsx
@@ -84,7 +84,7 @@ export default function BookCard({
     }
     try {
       if (isBookmarked) {
-        await removeFavouriteBook({ bookId: id }).unwrap();
+        await removeFavouriteBook({ userId, bookId: id }).unwrap();
         showToast('success', t('bookmark.removed'));
       } else {
         await addFavouriteBook({ userId, bookId: id }).unwrap();

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,9 @@
   padding: 0;
   margin: 0;
   box-sizing: border-box;
+}
+
+html {
   scroll-behavior: smooth;
 }
 

--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -13,9 +13,9 @@ export default function Layout() {
   useChatWS();
 
   return (
-    <div className="bg-light min-h-screen overflow-auto ">
+    <div className="bg-light min-h-screen overflow-auto flex flex-col">
       <Header />
-      <main>
+      <main className="flex-1">
         <LoginModal />
         <SwapModal />
         <Outlet />

--- a/src/pages/books/_components/CategorySlider.tsx
+++ b/src/pages/books/_components/CategorySlider.tsx
@@ -71,7 +71,7 @@ export default function CategorySlider({ isFixed }: { isFixed: boolean }) {
             : genres?.map((genre) => (
                 <CarouselItem key={genre.id} className="basis-1/4">
                   <Button
-                    className={`w-full h-[37px] rounded-full text-sm shadow-sm  ${isFixed ? 'border border-platinum' : ''} ${
+                    className={`w-full h-[37px] rounded-full text-sm shadow-sm transition-colors duration-200 ${isFixed ? 'border border-platinum' : ''} ${
                       genre.name === selectedGenre
                         ? 'bg-primary text-white'
                         : 'bg-white text-grayDark'

--- a/src/pages/books/_components/Filter.tsx
+++ b/src/pages/books/_components/Filter.tsx
@@ -29,34 +29,28 @@ export default function Filter() {
 
   useEffect(() => {
     const headerHeight = 80;
+    let ticking = false;
+
     const handleScroll = () => {
-      if (!filterRef.current || !placeholderRef.current) return;
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        ticking = false;
+        if (!placeholderRef.current || !filterRef.current) return;
 
-      const rect = placeholderRef.current.getBoundingClientRect();
-      const shouldBeFixed = rect.top <= headerHeight;
+        const rect = placeholderRef.current.getBoundingClientRect();
+        const shouldBeFixed = rect.top <= headerHeight;
 
-      if (shouldBeFixed && !isFixed) {
-        // measure before taking out of document flow
-        const height = filterRef.current.getBoundingClientRect().height;
-        placeholderRef.current.style.height = `${height}px`;
-        setIsFixed(true);
-      } else if (!shouldBeFixed && isFixed) {
-        // play slide-out animation while keeping the element fixed,
-        // then switch back to relative after animation completes to avoid jump
-        const el = filterRef.current;
-        if (!el) return;
-        const onAnimationEnd = (ev: AnimationEvent) => {
-          if (ev.animationName === 'filterSlideOut') {
-            el.classList.remove('filter-slide-out');
-            setIsFixed(false);
-            placeholderRef.current!.style.height = 'auto';
-            el.removeEventListener('animationend', onAnimationEnd as any);
+        if (shouldBeFixed !== isFixed) {
+          if (shouldBeFixed) {
+            const height = filterRef.current.getBoundingClientRect().height;
+            placeholderRef.current.style.height = `${height}px`;
+          } else {
+            placeholderRef.current.style.height = 'auto';
           }
-        };
-
-        el.addEventListener('animationend', onAnimationEnd as any);
-        el.classList.add('filter-slide-out');
-      }
+          setIsFixed(shouldBeFixed);
+        }
+      });
     };
 
     window.addEventListener('scroll', handleScroll, { passive: true });
@@ -64,47 +58,27 @@ export default function Filter() {
     return () => window.removeEventListener('scroll', handleScroll);
   }, [isFixed]);
 
-  const slideStyle = `
-.filter-slide-in {
-  animation: filterSlideIn 220ms cubic-bezier(.25,.8,.25,1) both;
-  will-change: transform;
-}
-@keyframes filterSlideIn {
-  from { transform: translateY(-12px); }
-  to { transform: translateY(0); }
-}
-.filter-slide-out {
-  animation: filterSlideOut 180ms cubic-bezier(.4,0,.2,1) both;
-  will-change: transform;
-}
-@keyframes filterSlideOut {
-  from { transform: translateY(0); }
-  to { transform: translateY(-12px); }
-}
-`;
-
   const isFilterOrCategoryOrSortByFn = (value: FilterItemEnum | null) => {
     dispatch(setIsCategoryOrFilterOrSortBy(value));
     dispatch(setFilterOpen(true));
   };
 
   return (
-    <div ref={placeholderRef} className="w-full  ">
-      <style>{slideStyle}</style>
+    <div ref={placeholderRef} className="w-full">
       <div
         ref={filterRef}
-        className={`z-10 ${
+        className={`z-10 transition-[transform,box-shadow,background-color] duration-300 ease-[cubic-bezier(0.25,0.8,0.25,1)] ${
           isFixed
-            ? 'fixed top-[80px] left-0 right-0 bg-white shadow-md border-t border-platinumMix filter-slide-in'
-            : 'relative bg-transparent border-none'
+            ? 'fixed top-[80px] left-0 right-0 bg-white shadow-md border-t border-platinumMix translate-y-0'
+            : 'relative bg-transparent border-none translate-y-0'
         }`}
       >
         <div
-          className={`${isFixed ? 'container py-3' : 'pb-6 pt-5 '}  flex items-center justify-between`}
+          className={`${isFixed ? 'container py-3' : 'pb-6 pt-5'} flex items-center justify-between`}
         >
-          <div className="flex items-center gap-2  ">
+          <div className="flex items-center gap-2">
             <Button
-              className=" bg-primary flex items-center gap-2 text-white px-4 py-2 rounded-lg font-poppins text-sm font-medium"
+              className="bg-primary flex items-center gap-2 text-white px-4 py-2 rounded-lg font-poppins text-sm font-medium"
               onClick={() => {
                 if (userInformation.id) {
                   navigate(`/profile/user-profile/${userInformation.id}`);
@@ -117,22 +91,22 @@ export default function Filter() {
               {t('books.addBook')}
             </Button>
           </div>
-          <div className=" flex-1 min-w-0 max-w-[48%] ">
+          <div className="flex-1 min-w-0 max-w-[48%]">
             <CategorySlider isFixed={isFixed} />
           </div>
 
-          <div className="flex items-center gap-2 ">
+          <div className="flex items-center gap-2">
             <Button
               onClick={() => isFilterOrCategoryOrSortByFn(FilterItemEnum.FILTER)}
-              className=" border border-platinum bg-white flex items-center gap-2 text-blackOlive px-4 py-2 rounded-lg font-poppins text-sm font-medium"
+              className="border border-platinum bg-white flex items-center gap-2 text-blackOlive px-4 py-2 rounded-lg font-poppins text-sm font-medium"
             >
-              <Image src={filtergrayIcon} alt="category" /> {t('books.filter')}
+              <Image src={filtergrayIcon} alt="filter" /> {t('books.filter')}
             </Button>
             <Button
               onClick={() => isFilterOrCategoryOrSortByFn(FilterItemEnum.SORTBY)}
-              className=" border border-platinum bg-white flex items-center gap-2 text-blackOlive px-4 py-2 rounded-lg font-poppins text-sm font-medium"
+              className="border border-platinum bg-white flex items-center gap-2 text-blackOlive px-4 py-2 rounded-lg font-poppins text-sm font-medium"
             >
-              <Image src={sortByIcon} alt="category" /> {t('books.sort')}
+              <Image src={sortByIcon} alt="sort" /> {t('books.sort')}
               <MdKeyboardArrowDown />
             </Button>
           </div>

--- a/src/pages/books/_components/NoBooksAvailable.tsx
+++ b/src/pages/books/_components/NoBooksAvailable.tsx
@@ -1,6 +1,4 @@
 import { useTranslation } from 'react-i18next';
-import NotFound from '../../../assets/notFound.png';
-import Image from '../../../components/shared/Image';
 
 export default function NoBooksAvailable() {
   const { t } = useTranslation();
@@ -10,10 +8,7 @@ export default function NoBooksAvailable() {
         <h3 className="text-xl lg:text-2xl font-semibold mb-2 font-poppins text-[#262626]">
           {t('books.noBooks')}
         </h3>
-        <p className="text-sm text-[#262626] mb-4 font-poppins text-center">
-          {t('books.noBooksDesc')}
-        </p>
-        <Image src={NotFound} alt="not found" className="w-28 lg:w-40" />
+        <p className="text-sm text-[#262626] font-poppins text-center">{t('books.noBooksDesc')}</p>
       </div>
     </div>
   );

--- a/src/redux/feature/auth/authApi.ts
+++ b/src/redux/feature/auth/authApi.ts
@@ -194,13 +194,46 @@ export const authApi = api.injectEndpoints({
         body: { userId, bookId },
       }),
       invalidatesTags: ['UpdateUser'],
+      async onQueryStarted({ userId, bookId }, { dispatch, queryFulfilled }) {
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        const updateQueryData = (api as any).util.updateQueryData;
+        const patchResult = dispatch(
+          updateQueryData('getUserById', { userId }, (draft: any) => {
+            if (!draft.favBooks) draft.favBooks = [];
+            draft.favBooks.push({ id: bookId });
+          }),
+        );
+        /* eslint-enable @typescript-eslint/no-explicit-any */
+        try {
+          await queryFulfilled;
+        } catch {
+          patchResult.undo();
+        }
+      },
     }),
     removeFavouriteBook: builder.mutation({
-      query: ({ bookId }: { bookId: string }) => ({
+      query: ({ bookId }: { userId: string; bookId: string }) => ({
         url: `/users/favourite-books/${bookId}`,
         method: 'DELETE',
       }),
       invalidatesTags: ['UpdateUser'],
+      async onQueryStarted({ userId, bookId }, { dispatch, queryFulfilled }) {
+        /* eslint-disable @typescript-eslint/no-explicit-any */
+        const updateQueryData = (api as any).util.updateQueryData;
+        const patchResult = dispatch(
+          updateQueryData('getUserById', { userId }, (draft: any) => {
+            if (draft.favBooks) {
+              draft.favBooks = draft.favBooks.filter((fav: { id: string }) => fav.id !== bookId);
+            }
+          }),
+        );
+        /* eslint-enable @typescript-eslint/no-explicit-any */
+        try {
+          await queryFulfilled;
+        } catch {
+          patchResult.undo();
+        }
+      },
     }),
     changePassword: builder.mutation({
       query: ({


### PR DESCRIPTION
## Summary
- **Optimistic bookmark updates**: Add/remove favourite book mutations now update the UI instantly via RTK Query `onQueryStarted` cache patches, rolling back on error
- **Sort filter redesign**: Single-select (radio) behavior with collapsible header, radio dot indicator, matching the Language/Condition filter theme
- **Genre filter alignment**: Consistent `h-[28px]` row height for all items, arrow icons wrapped in fixed-width container to align with plus/tick icons, `w-full` → `w-4 flex-shrink-0` on all select icons
- **Language/Condition filters**: Same icon sizing fix (`w-full` → `w-4 flex-shrink-0`)
- **Smooth scroll & sticky filter bar**: Moved `scroll-behavior: smooth` from `*` to `html` only; replaced keyframe animation + `animationend` listener with CSS `transition` for the sticky filter bar
- **Footer pinned to bottom**: Layout uses `flex flex-col` + `flex-1` on main so footer never floats up on short pages
- **Removed search icon** from empty books state
- **Category pill transitions**: Smooth color animation on genre select/deselect

## Test plan
- [x] All 199 test files pass (1366 tests)
- [x] Type check clean (`tsc -b`)
- [x] Lint + format clean (`npm run spotless`)
- [ ] Click bookmark → icon fills instantly, toast shows; click again → icon outlines instantly
- [ ] If bookmark request fails, icon rolls back
- [ ] Sort filter: only one option selectable at a time, collapses/expands
- [ ] Genre filter: arrow and plus/tick icons aligned in a column
- [ ] Footer stays at bottom on pages with little content
- [ ] Scrolling past the filter bar → it sticks smoothly, no jump
- [ ] Scroll performance feels smooth (no jank from scroll-behavior on all elements)