### PR TITLE
Fix: remove auto-select first chat on messages page

### DIFF
--- a/src/__tests__/components/messages/ChatList.test.tsx
+++ b/src/__tests__/components/messages/ChatList.test.tsx
@@ -444,7 +444,7 @@ describe('ChatList Component', () => {
     expect(screen.getByText('📷 Image')).toBeInTheDocument();
   });
 
-  it('should auto-select first chat on initial load', async () => {
+  it('should not auto-select first chat on initial load', async () => {
     mockUseGetInboxQuery.mockReturnValue({
       data: mockInboxData,
       isLoading: false,
@@ -455,8 +455,11 @@ describe('ChatList Component', () => {
 
     await waitFor(() => {
       const state = store.getState();
-      expect(state.chat.selectedChatId).toBeTruthy();
+      expect(state.chat.chats.length).toBeGreaterThan(0);
     });
+
+    const state = store.getState();
+    expect(state.chat.selectedChatId).toBe('');
   });
 
   it('should navigate to chat on click', async () => {

--- a/src/__tests__/functional/chatFlow.test.tsx
+++ b/src/__tests__/functional/chatFlow.test.tsx
@@ -163,9 +163,8 @@ describe('Chat Messaging Flow (Functional)', () => {
 
     // Step 2: Click a chat to select it
     const chatButton = screen.getAllByText('Test Book')[0].closest('button');
-    if (chatButton) {
-      await user.click(chatButton);
-    }
+    expect(chatButton).not.toBeNull();
+    await user.click(chatButton as HTMLButtonElement);
 
     // Step 3: Chat messages load after selection
     await waitFor(() => {

--- a/src/__tests__/functional/chatFlow.test.tsx
+++ b/src/__tests__/functional/chatFlow.test.tsx
@@ -161,16 +161,22 @@ describe('Chat Messaging Flow (Functional)', () => {
       expect(screen.getAllByText('Test Book').length).toBeGreaterThan(0);
     });
 
-    // Step 2: Chat messages load automatically
+    // Step 2: Click a chat to select it
+    const chatButton = screen.getAllByText('Test Book')[0].closest('button');
+    if (chatButton) {
+      await user.click(chatButton);
+    }
+
+    // Step 3: Chat messages load after selection
     await waitFor(() => {
       expect(mockUseGetChatMessagesQuery).toHaveBeenCalled();
     });
 
-    // Step 3: Type and send a message
+    // Step 4: Type a message
     const input = screen.getByPlaceholderText('chat.writeHere');
     await user.type(input, 'New message from test');
 
-    // Step 4: Verify input has value
+    // Step 5: Verify input has value
     expect(input).toHaveValue('New message from test');
   });
 
@@ -184,15 +190,18 @@ describe('Chat Messaging Flow (Functional)', () => {
     });
   });
 
-  it('should auto-select first chat from inbox', async () => {
+  it('should not auto-select first chat from inbox', async () => {
     window.history.pushState({}, '', '/user/messages');
 
     const { store } = renderMessages();
 
     await waitFor(() => {
       const state = store.getState();
-      expect(state.chat.selectedChatId).toBeTruthy();
+      expect(state.chat.chats.length).toBeGreaterThan(0);
     });
+
+    const state = store.getState();
+    expect(state.chat.selectedChatId).toBe('');
   });
 
   it('should fetch messages for selected chat', async () => {

--- a/src/pages/messages/components/ChatList.tsx
+++ b/src/pages/messages/components/ChatList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IoIosSearch } from 'react-icons/io';
 import { createSearchParams, useNavigate } from 'react-router-dom';
@@ -17,7 +17,6 @@ export default function ChatList() {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const [search, setSearch] = useState('');
-  const hasAutoSelected = useRef(false);
 
   const { chats, selectedChatId } = useAppSelector((state) => state.chat);
   const { userInformation } = useAppSelector((state) => state.auth);
@@ -34,22 +33,8 @@ export default function ChatList() {
 
   useEffect(() => {
     if (!isSuccess || !Array.isArray(inboxData) || inboxData.length === 0) return;
-
     dispatch(setInboxList(inboxData));
-
-    if (!hasAutoSelected.current && !selectedChatId) {
-      const firstChatId = inboxData[0].id;
-      hasAutoSelected.current = true;
-      dispatch(selectChat(firstChatId));
-      navigate(
-        {
-          pathname: '/user/messages',
-          search: `?${createSearchParams({ messageId: firstChatId })}`,
-        },
-        { replace: true },
-      );
-    }
-  }, [isSuccess, inboxData, dispatch, navigate, selectedChatId]);
+  }, [isSuccess, inboxData, dispatch]);
 
   const filteredChats = chats.filter((chat) => {
     if (!search) return true;


### PR DESCRIPTION
## Summary
- Removed auto-select logic that picked the first chat when navigating to `/user/messages`
- Users now land on the chat list and must click a chat to open it (both mobile and desktop)
- Deep links via `?messageId=` continue to work as before

## Test plan
- [ ] Navigate to Messages page — should show chat list without any chat selected
- [ ] Click a chat from the list — should open the chat window
- [ ] On mobile, back arrow from chat returns to the list
- [ ] Deep link `/user/messages?messageId=swap-1` still opens that chat directly
- [ ] All 198 test files pass (1368 tests)