### PR TITLE
Fix: logout state reset, mark-as-read badge sync, chat auto-scroll

### DIFF
--- a/src/__tests__/components/Header/UserMenuDropdown.test.tsx
+++ b/src/__tests__/components/Header/UserMenuDropdown.test.tsx
@@ -14,11 +14,38 @@ vi.mock('react-icons/md', () => ({
 vi.mock('react-icons/tb', () => ({ TbUserCircle: () => <span>user</span> }));
 
 vi.mock('../../../redux/api/apiSlice', () => ({
-  api: { util: { resetApiState: () => ({ type: 'api/resetApiState' }) } },
+  api: {
+    util: { resetApiState: () => ({ type: 'api/resetApiState' }) },
+    injectEndpoints: vi.fn(() => ({ endpoints: {} })),
+  },
 }));
 
 vi.mock('../../../redux/feature/auth/authSlice', () => ({
   logout: () => ({ type: 'auth/logout' }),
+}));
+
+vi.mock('../../../redux/feature/filter/filterSlice', () => ({
+  clearAllFilters: () => ({ type: 'filter/clearAllFilters' }),
+}));
+
+vi.mock('../../../redux/feature/messages/messagesSlice', () => ({
+  resetChat: () => ({ type: 'chat/resetChat' }),
+}));
+
+vi.mock('../../../redux/feature/notification/notificationSlice', () => ({
+  clearNotifications: () => ({ type: 'notification/clearNotifications' }),
+}));
+
+vi.mock('../../../redux/feature/open/openSlice', () => ({
+  setOpen: (val: boolean) => ({ type: 'open/setOpen', payload: val }),
+}));
+
+vi.mock('../../../redux/feature/step/stepSlice', () => ({
+  setStep: (val: number) => ({ type: 'step/setStep', payload: val }),
+}));
+
+vi.mock('../../../redux/feature/swap/swapSlice', () => ({
+  setResetSwapBook: () => ({ type: 'swap/setResetSwapBook' }),
 }));
 
 vi.mock('../../../components/shared/Button', () => ({

--- a/src/components/Header/_components/UserMenuDropdown.tsx
+++ b/src/components/Header/_components/UserMenuDropdown.tsx
@@ -6,6 +6,12 @@ import { useDispatch } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 import { api } from '../../../redux/api/apiSlice';
 import { logout } from '../../../redux/feature/auth/authSlice';
+import { clearAllFilters } from '../../../redux/feature/filter/filterSlice';
+import { resetChat } from '../../../redux/feature/messages/messagesSlice';
+import { clearNotifications } from '../../../redux/feature/notification/notificationSlice';
+import { setOpen } from '../../../redux/feature/open/openSlice';
+import { setStep } from '../../../redux/feature/step/stepSlice';
+import { setResetSwapBook } from '../../../redux/feature/swap/swapSlice';
 import { useAppSelector } from '../../../redux/hooks';
 import Button from '../../shared/Button';
 import { showToast } from '../../shared/toast';
@@ -64,6 +70,12 @@ export default function UserMenuDropdown() {
             onClick={() => {
               dispatch(logout());
               dispatch(api.util.resetApiState());
+              dispatch(clearAllFilters());
+              dispatch(resetChat());
+              dispatch(setResetSwapBook());
+              dispatch(clearNotifications());
+              dispatch(setStep(0));
+              dispatch(setOpen(false));
               showToast('success', 'Logout successfully');
               navigate('/');
             }}

--- a/src/pages/messages/components/ChatWindow.tsx
+++ b/src/pages/messages/components/ChatWindow.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IoChatbubblesOutline } from 'react-icons/io5';
 import Image from '../../../components/shared/Image';
+import { api } from '../../../redux/api/apiSlice';
 import { useGetChatMessagesQuery } from '../../../redux/feature/messages/inboxApi';
 import { addChatMessages, markChatRead } from '../../../redux/feature/messages/messagesSlice';
 import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
@@ -10,6 +11,7 @@ export default function ChatWindow() {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
   const bottomRef = useRef<HTMLDivElement>(null);
+  const isInitialScroll = useRef(true);
   const { selectedChatId, chats } = useAppSelector((state) => state.chat);
   const { userInformation } = useAppSelector((state) => state.auth);
 
@@ -37,11 +39,20 @@ export default function ChatWindow() {
 
     dispatch(addChatMessages({ chatId: selectedChatId, messages: mapped }));
     dispatch(markChatRead(selectedChatId));
+    dispatch(api.util.invalidateTags(['Inbox']));
   }, [dispatch, selectedChatId, chatData, isChatSuccess]);
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+    if (!findChat?.messages?.length) return;
+    bottomRef.current?.scrollIntoView({
+      behavior: isInitialScroll.current ? 'instant' : 'smooth',
+    });
+    isInitialScroll.current = false;
   }, [findChat?.messages]);
+
+  useEffect(() => {
+    isInitialScroll.current = true;
+  }, [selectedChatId]);
 
   if (!selectedChatId) {
     return (

--- a/src/redux/feature/messages/messagesSlice.ts
+++ b/src/redux/feature/messages/messagesSlice.ts
@@ -95,9 +95,7 @@ const chatSlice = createSlice({
     selectChat: (state, action: PayloadAction<string>) => {
       state.selectedChatId = action.payload;
     },
-    resetChat: (state) => {
-      state.selectedChatId = '';
-    },
+    resetChat: () => initialState,
     setInboxList: (state, action: PayloadAction<InboxItem[]>) => {
       // Deduplicate inbox items by ID before transforming (more efficient using Map)
       const uniqueItemsMap = new Map<string, InboxItem>();


### PR DESCRIPTION
## Summary
- **Logout resets all app state**: On logout, all Redux slices (chat, filter, swap, notifications, step, open) are now cleared alongside auth and RTK Query cache. Previously, stale data persisted across user sessions.
- **Mark-as-read syncs sidebar badges immediately**: After opening a chat, the Inbox RTK Query cache is invalidated so unread badges update instantly instead of waiting for the 30s auto-refetch. The backend already marks messages as read on `GET /chat` — this just ensures the frontend reflects it.
- **Auto-scroll**: Uses instant scroll when first opening a chat (no jarring animation) and smooth scroll for subsequent new messages. Resets on chat switch.

## Test plan
- [ ] Log in → browse books → apply filters → open messages → log out → log in as different user → verify no stale data (chats, filters, notifications all cleared)
- [ ] Open a chat with unread badge → verify badge clears immediately in sidebar
- [ ] Open a chat → verify instant scroll to latest message → send a message → verify smooth scroll to new message
- [ ] Switch between chats → verify scroll resets to bottom each time
- [ ] `npm run test` — 198/198 pass
- [ ] `npm run build` — clean