### PR TITLE
Fix: mark-as-read badge, chat auto-scroll, broken images

### DIFF
--- a/src/__tests__/redux/messagesSlice.test.ts
+++ b/src/__tests__/redux/messagesSlice.test.ts
@@ -120,6 +120,47 @@ describe('messagesSlice', () => {
 
       expect(result.chats).toEqual([]);
     });
+
+    it('should preserve local read state for selected chat', () => {
+      const stateWithReadChat: ChatState = {
+        chats: [
+          {
+            id: 'swap-123',
+            name: 'Test Book',
+            unread: false,
+            unreadMessageCount: 0,
+            messages: [{ id: 'msg-1', sender: 'them', text: 'Hello', time: '2024-01-01' }],
+          },
+        ],
+        selectedChatId: 'swap-123',
+      };
+
+      // Server still reports unread, but local state should be preserved
+      const result = messagesSlice(stateWithReadChat, setInboxList([mockInboxItem]));
+
+      expect(result.chats[0].unread).toBe(false);
+      expect(result.chats[0].unreadMessageCount).toBe(0);
+    });
+
+    it('should not preserve read state for non-selected chat', () => {
+      const stateWithReadChat: ChatState = {
+        chats: [
+          {
+            id: 'swap-123',
+            name: 'Test Book',
+            unread: false,
+            unreadMessageCount: 0,
+            messages: [{ id: 'msg-1', sender: 'them', text: 'Hello', time: '2024-01-01' }],
+          },
+        ],
+        selectedChatId: 'other-chat',
+      };
+
+      const result = messagesSlice(stateWithReadChat, setInboxList([mockInboxItem]));
+
+      expect(result.chats[0].unread).toBe(true);
+      expect(result.chats[0].unreadMessageCount).toBe(2);
+    });
   });
 
   describe('updateInboxItem', () => {
@@ -165,6 +206,26 @@ describe('messagesSlice', () => {
       const result = messagesSlice(stateWithChats, updateInboxItem(mockInboxItem));
 
       expect(result.chats[0].id).toBe('swap-123');
+    });
+
+    it('should preserve local read state for selected chat', () => {
+      const stateWithReadChat: ChatState = {
+        chats: [
+          {
+            id: 'swap-123',
+            name: 'Test Book',
+            unread: false,
+            unreadMessageCount: 0,
+            messages: [{ id: 'msg-1', sender: 'me', text: 'Test', time: '2024-01-01' }],
+          },
+        ],
+        selectedChatId: 'swap-123',
+      };
+
+      const result = messagesSlice(stateWithReadChat, updateInboxItem(mockInboxItem));
+
+      expect(result.chats[0].unread).toBe(false);
+      expect(result.chats[0].unreadMessageCount).toBe(0);
     });
   });
 

--- a/src/components/shared/Image.tsx
+++ b/src/components/shared/Image.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, RefObject, useState } from 'react';
+import React, { CSSProperties, RefObject, useEffect, useState } from 'react';
 import NotFoundImg from '../../assets/notFoundIcon.png';
 import { cn } from '../../utility/cn';
 
@@ -16,6 +16,10 @@ interface IImageProps {
 const Image: React.FC<IImageProps> = (props) => {
   const { src, style, className } = props;
   const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    setIsLoaded(false);
+  }, [src]);
   // Image Error Handling Function
   const handleImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
     const img = event.target as HTMLImageElement;

--- a/src/pages/messages/components/ChatWindow.tsx
+++ b/src/pages/messages/components/ChatWindow.tsx
@@ -44,10 +44,12 @@ export default function ChatWindow() {
 
   useEffect(() => {
     if (!findChat?.messages?.length) return;
-    bottomRef.current?.scrollIntoView({
-      behavior: isInitialScroll.current ? 'instant' : 'smooth',
+    requestAnimationFrame(() => {
+      bottomRef.current?.scrollIntoView({
+        behavior: isInitialScroll.current ? 'instant' : 'smooth',
+      });
+      isInitialScroll.current = false;
     });
-    isInitialScroll.current = false;
   }, [findChat?.messages]);
 
   useEffect(() => {

--- a/src/pages/messages/components/ChatWindow.tsx
+++ b/src/pages/messages/components/ChatWindow.tsx
@@ -12,6 +12,7 @@ export default function ChatWindow() {
   const dispatch = useAppDispatch();
   const bottomRef = useRef<HTMLDivElement>(null);
   const isInitialScroll = useRef(true);
+  const scrollRafId = useRef<number>();
   const { selectedChatId, chats } = useAppSelector((state) => state.chat);
   const { userInformation } = useAppSelector((state) => state.auth);
 
@@ -44,12 +45,15 @@ export default function ChatWindow() {
 
   useEffect(() => {
     if (!findChat?.messages?.length) return;
-    requestAnimationFrame(() => {
+    scrollRafId.current = requestAnimationFrame(() => {
       bottomRef.current?.scrollIntoView({
         behavior: isInitialScroll.current ? 'instant' : 'smooth',
       });
       isInitialScroll.current = false;
     });
+    return () => {
+      if (scrollRafId.current) cancelAnimationFrame(scrollRafId.current);
+    };
   }, [findChat?.messages]);
 
   useEffect(() => {

--- a/src/redux/feature/messages/messagesSlice.ts
+++ b/src/redux/feature/messages/messagesSlice.ts
@@ -155,11 +155,17 @@ const chatSlice = createSlice({
       const bookTitle = item.bookToSwapWith?.title || 'Unknown Book';
       const lastText = item.note || `${item.sender.name} sent a message`;
 
+      // Preserve local read state for the currently selected chat
+      const existingChat = existingChatIndex !== -1 ? state.chats[existingChatIndex] : null;
+      const isCurrentlySelected = state.selectedChatId === item.id;
+      const wasLocallyRead = existingChat && !existingChat.unread;
+
       const updatedChat: Chat = {
         id: item.id,
         name: bookTitle,
-        unread: item.unread,
-        unreadMessageCount: item.unreadMessageCount || 0,
+        unread: isCurrentlySelected && wasLocallyRead ? false : item.unread,
+        unreadMessageCount:
+          isCurrentlySelected && wasLocallyRead ? 0 : item.unreadMessageCount || 0,
         senderName: partnerName,
         updatedAt: item.updatedAt,
         conversationType: item.conversationType,
@@ -175,7 +181,7 @@ const chatSlice = createSlice({
             sender: item.conversationType === 'sent' ? 'me' : 'them',
             text: lastText,
             time: item.updatedAt,
-            unread: item.unread,
+            unread: isCurrentlySelected && wasLocallyRead ? false : item.unread,
           },
         ],
       };

--- a/src/redux/feature/messages/messagesSlice.ts
+++ b/src/redux/feature/messages/messagesSlice.ts
@@ -116,11 +116,16 @@ const chatSlice = createSlice({
         // Find existing chat to preserve loaded messages
         const existingChat = state.chats.find((c) => c.id === item.id);
 
+        // Preserve local read state for the currently selected chat
+        const isCurrentlySelected = state.selectedChatId === item.id;
+        const wasLocallyRead = existingChat && !existingChat.unread;
+
         return {
           id: item.id,
           name: bookTitle,
-          unread: item.unread,
-          unreadMessageCount: item.unreadMessageCount || 0,
+          unread: isCurrentlySelected && wasLocallyRead ? false : item.unread,
+          unreadMessageCount:
+            isCurrentlySelected && wasLocallyRead ? 0 : item.unreadMessageCount || 0,
           senderName: partnerName,
           updatedAt: item.updatedAt,
           conversationType: item.conversationType,


### PR DESCRIPTION
## Summary
- **Mark-as-read badge now persists**: `setInboxList` was overwriting the locally cleared unread state when the inbox refetched. Now preserves `unread: false` and `unreadMessageCount: 0` for the currently selected chat that was locally marked as read.
- **Auto-scroll works on chat open**: Wrapped `scrollIntoView` in `requestAnimationFrame` so the DOM layout completes before scrolling. Uses `instant` on initial chat open and `smooth` for subsequent new messages.
- **Book images no longer break on reload**: The `Image` component now resets its `isLoaded` state when the `src` prop changes, preventing stale/broken image flash when presigned URLs are refreshed.

## Test plan
- [ ] Open a chat with unread badge → badge clears and stays cleared (no re-flash from inbox refetch)
- [ ] Open a chat with many messages → scrolls instantly to bottom
- [ ] Send/receive a message → smoothly scrolls to new message
- [ ] Switch between chats → scroll resets to bottom each time
- [ ] Reload the page on chat inbox → book cover images load correctly
- [ ] `npm run test` — 198/198 pass
- [ ] `npm run build` — clean