### PR TITLE
Fix: scroll jitter, image recovery, mobile login flow, Google button width

### DIFF
--- a/src/__tests__/components/shared/GoogleLoginButton.test.tsx
+++ b/src/__tests__/components/shared/GoogleLoginButton.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { api } from '../../../redux/api/apiSlice';
+
+const OriginalResizeObserver = globalThis.ResizeObserver;
 
 beforeAll(() => {
   globalThis.ResizeObserver = class {
@@ -10,6 +12,10 @@ beforeAll(() => {
     unobserve() {}
     disconnect() {}
   } as unknown as typeof ResizeObserver;
+});
+
+afterAll(() => {
+  globalThis.ResizeObserver = OriginalResizeObserver;
 });
 
 // Mock @react-oauth/google before importing the component

--- a/src/__tests__/components/shared/GoogleLoginButton.test.tsx
+++ b/src/__tests__/components/shared/GoogleLoginButton.test.tsx
@@ -1,8 +1,16 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { api } from '../../../redux/api/apiSlice';
+
+beforeAll(() => {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+});
 
 // Mock @react-oauth/google before importing the component
 vi.mock('@react-oauth/google', () => ({

--- a/src/__tests__/components/shared/Image.test.tsx
+++ b/src/__tests__/components/shared/Image.test.tsx
@@ -48,14 +48,13 @@ describe('Image Component', () => {
     expect(img).toHaveClass('opacity-100');
   });
 
-  it('calls onError and swaps src to notFoundIcon on image error', () => {
+  it('swaps src to notFoundIcon on image error', () => {
     render(<Image src="https://example.com/bad.jpg" alt="Bad" />);
     const img = screen.getByRole('img');
 
-    Object.defineProperty(img, 'src', { writable: true, value: 'https://example.com/bad.jpg' });
     fireEvent.error(img);
 
-    expect((img as HTMLImageElement).src).toContain('notFoundIcon.png');
+    expect(img).toHaveAttribute('src', 'notFoundIcon.png');
   });
 
   it('calls onClick when provided', () => {

--- a/src/components/Footer/_components/BottomNav.tsx
+++ b/src/components/Footer/_components/BottomNav.tsx
@@ -2,14 +2,18 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { menu } from '../../../data/menu';
 import { selectTotalUnreadCount } from '../../../redux/feature/messages/messagesSlice';
-import { useAppSelector } from '../../../redux/hooks';
+import { setLoginModalOpen } from '../../../redux/feature/open/openSlice';
+import { useAppDispatch, useAppSelector } from '../../../redux/hooks';
 import NotificationBell from '../../Header/_components/NotificationBell';
 import BottomNavItem from './BottomNavItem';
 
 export default function BottomNav() {
   const { t } = useTranslation();
   const location = useLocation();
+  const dispatch = useAppDispatch();
   const totalUnreadCount = useAppSelector(selectTotalUnreadCount);
+  const { userInformation } = useAppSelector((state) => state.auth);
+  const isAuthenticated = Boolean(userInformation?.id && userInformation?.email);
   const pathname = location.pathname;
   const ignorePath: string[] = [`/book-details/${pathname?.split('/').reverse()[0]}`];
   const isFooterBarShow = ignorePath.includes(pathname);
@@ -27,6 +31,7 @@ export default function BottomNav() {
             const isActive = location.pathname === menuItem?.route;
             const isMessagesMenu = menuItem.value === 'messages';
             const badgeCount = isMessagesMenu ? totalUnreadCount : undefined;
+            const needsAuth = isMessagesMenu && !isAuthenticated;
             return (
               <div key={index} className={`${index === 2 && pathname === '/' ? 'pl-24' : ''}`}>
                 <BottomNavItem
@@ -35,6 +40,14 @@ export default function BottomNav() {
                   icon={menuItem.icon}
                   value={t(menuItem.value)}
                   badgeCount={badgeCount}
+                  onClick={
+                    needsAuth
+                      ? (e) => {
+                          e.preventDefault();
+                          dispatch(setLoginModalOpen(true));
+                        }
+                      : undefined
+                  }
                 />
               </div>
             );

--- a/src/components/Footer/_components/BottomNavItem.tsx
+++ b/src/components/Footer/_components/BottomNavItem.tsx
@@ -7,6 +7,7 @@ interface IBottomNavItem {
   readonly isActive: boolean;
   readonly value: string;
   readonly badgeCount?: number;
+  readonly onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
 }
 
 export default function BottomNavItem({
@@ -15,12 +16,14 @@ export default function BottomNavItem({
   isActive,
   value,
   badgeCount,
+  onClick,
 }: IBottomNavItem) {
   const showBadge = !!badgeCount && badgeCount > 0;
 
   return (
     <Link
       to={route || '#'}
+      onClick={onClick}
       className={`flex flex-col items-center gap-1 p-1 relative`}
       style={{
         transition: 'background-color 0.2s ease-in-out',

--- a/src/components/shared/GoogleLoginButton.tsx
+++ b/src/components/shared/GoogleLoginButton.tsx
@@ -13,9 +13,10 @@ export default function GoogleLoginButton() {
   const [buttonWidth, setButtonWidth] = useState<number | undefined>(undefined);
 
   useEffect(() => {
-    if (!containerRef.current) return;
+    if (!containerRef.current || typeof ResizeObserver === 'undefined') return;
     const observer = new ResizeObserver(([entry]) => {
-      setButtonWidth(Math.floor(entry.contentRect.width));
+      const width = Math.floor(entry.contentRect.width);
+      setButtonWidth(width > 0 ? width : undefined);
     });
     observer.observe(containerRef.current);
     return () => observer.disconnect();

--- a/src/components/shared/GoogleLoginButton.tsx
+++ b/src/components/shared/GoogleLoginButton.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from 'react';
 import type { CredentialResponse } from '@react-oauth/google';
 import { GoogleLogin } from '@react-oauth/google';
 import { useLoginWithGoogleMutation } from '../../redux/feature/auth/authApi';
@@ -8,6 +9,18 @@ import { showToast } from './toast';
 export default function GoogleLoginButton() {
   const [loginWithGoogle] = useLoginWithGoogleMutation();
   const dispatch = useAppDispatch();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [buttonWidth, setButtonWidth] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const observer = new ResizeObserver(([entry]) => {
+      setButtonWidth(Math.floor(entry.contentRect.width));
+    });
+    observer.observe(containerRef.current);
+    return () => observer.disconnect();
+  }, []);
+
   const handleGoogleLogin = (credentialResponse: CredentialResponse): void => {
     const idToken = credentialResponse.credential;
     if (idToken) {
@@ -27,10 +40,11 @@ export default function GoogleLoginButton() {
   };
 
   return (
-    <div>
+    <div ref={containerRef}>
       <GoogleLogin
         onSuccess={handleGoogleLogin}
         onError={() => showToast('error', 'Something went wrong! Please try again.')}
+        width={buttonWidth}
       />
     </div>
   );

--- a/src/components/shared/Image.tsx
+++ b/src/components/shared/Image.tsx
@@ -16,22 +16,16 @@ interface IImageProps {
 const Image: React.FC<IImageProps> = (props) => {
   const { src, style, className } = props;
   const [isLoaded, setIsLoaded] = useState(false);
+  const [hasError, setHasError] = useState(false);
   const hasEverLoaded = useRef(false);
 
   useEffect(() => {
-    // Only show placeholder if we've never loaded an image.
-    // When src changes after a successful load (e.g. presigned URL rotation),
-    // keep the old image visible until the new one loads.
+    setHasError(false);
     if (!hasEverLoaded.current) {
       setIsLoaded(false);
     }
   }, [src]);
 
-  // Image Error Handling Function
-  const handleImageError = (event: React.SyntheticEvent<HTMLImageElement>) => {
-    const img = event.target as HTMLImageElement;
-    img.src = NotFoundImg;
-  };
   return (
     <picture>
       {!isLoaded && (
@@ -39,8 +33,8 @@ const Image: React.FC<IImageProps> = (props) => {
       )}
       <img
         {...props}
-        src={!src ? NotFoundImg : src}
-        onError={handleImageError}
+        src={!src || hasError ? NotFoundImg : src}
+        onError={() => setHasError(true)}
         onLoad={() => {
           setIsLoaded(true);
           hasEverLoaded.current = true;

--- a/src/index.css
+++ b/src/index.css
@@ -11,10 +11,6 @@
   box-sizing: border-box;
 }
 
-html {
-  scroll-behavior: smooth;
-}
-
 @layer utilities {
   .custom-scrollbar::-webkit-scrollbar {
     width: 11px;


### PR DESCRIPTION
## Summary

- **Desktop scroll jitter**: Remove `scroll-behavior: smooth` from `html` — it was causing the browser to interpolate all scroll position changes on desktop, conflicting with infinite scroll pagination and layout shifts. Programmatic smooth scroll (goToTop, chat scrollIntoView) already uses explicit `behavior: 'smooth'`.
- **Book images break on refresh in messages**: Replace direct DOM mutation in Image error handler (`img.src = NotFoundImg`) with React state (`hasError`). The old approach caused React and the DOM to desync — once the error handler mutated the DOM src, subsequent re-renders with fresh presigned URLs couldn't recover.
- **Mobile login flow**: Bottom nav "Messages" tap now shows login modal for unauthenticated users instead of navigating to `/auth/login` (consistent with notification bell behavior).
- **Google login button width**: Use `ResizeObserver` on the container to measure width and pass it to `GoogleLogin`'s `width` prop, making it match the regular login button's full width.

## Test plan

- [x] `npm run spotless` — passes
- [x] `npm run test` — 198 files, 1374 tests pass
- [x] `npm run build` — succeeds
- [ ] Scroll homepage on desktop — should be smooth, no jitter
- [ ] Refresh inside messages — book images should load correctly, not stay broken
- [ ] Tap messages in bottom nav while logged out — login modal should appear
- [ ] Login page — Google button should be full width matching the login button