### PR TITLE
Fix: pass WebSocket auth token as query param

### DIFF
--- a/src/hooks/useNotificationWS.ts
+++ b/src/hooks/useNotificationWS.ts
@@ -168,11 +168,13 @@ export const useNotificationWS = (): UseNotificationWSReturn => {
     try {
       const userToken = getCookie('userToken');
       const token = userToken || WS_API_KEY;
-      const wsUrl = `${WS_URL}?userId=${encodeURIComponent(userId)}`;
+      const params = new URLSearchParams({ userId });
+      if (token) params.set('token', token);
+      const wsUrl = `${WS_URL}?${params.toString()}`;
 
       dispatch(setWSConnectionStatus('connecting'));
 
-      const ws = new WebSocket(wsUrl, token ? [token] : []);
+      const ws = new WebSocket(wsUrl);
 
       ws.onopen = handleOpen;
       ws.onmessage = handleMessage;


### PR DESCRIPTION
## Summary
- The notification backend expects the auth token as a `?token=` query parameter, but the frontend was passing it as a WebSocket subprotocol (second arg to `new WebSocket`)
- This meant authentication was never reaching the server — connections only worked when auth was disabled
- Now passes `token` as a query param alongside `userId`, matching the Go backend's `r.URL.Query().Get("token")`

## Test plan
- [x] All 8 `useNotificationWS` tests pass
- [ ] Verify WebSocket connects successfully with JWT token in production
- [ ] Verify notifications are received in real-time after connection