### PR TITLE
Fix: add book navigation, bookmarked tab on mobile, sort arrow

### DIFF
--- a/src/__tests__/pages/books/Filter.test.tsx
+++ b/src/__tests__/pages/books/Filter.test.tsx
@@ -12,10 +12,6 @@ vi.mock('react-icons/fi', () => ({
   FiPlus: () => <span>+</span>,
 }));
 
-vi.mock('react-icons/md', () => ({
-  MdKeyboardArrowDown: () => <span>v</span>,
-}));
-
 vi.mock('../../../assets/categoryIcon.svg', () => ({ default: 'category.svg' }));
 vi.mock('../../../assets/filtergray.svg', () => ({ default: 'filter.svg' }));
 vi.mock('../../../assets/uiw_map.svg', () => ({ default: 'map.svg' }));

--- a/src/__tests__/pages/books/Filter.test.tsx
+++ b/src/__tests__/pages/books/Filter.test.tsx
@@ -114,9 +114,9 @@ describe('Filter', () => {
     expect(screen.getByTestId('category-slider')).toBeInTheDocument();
   });
 
-  it('navigates to profile when logged in user clicks Add Book', () => {
+  it('navigates to add book page when logged in user clicks Add Book', () => {
     renderComponent('user-123');
     fireEvent.click(screen.getByText(/books.addBook/));
-    expect(mockNavigate).toHaveBeenCalledWith('/profile/user-profile/user-123');
+    expect(mockNavigate).toHaveBeenCalledWith('/profile/add-book');
   });
 });

--- a/src/pages/books/_components/Filter.tsx
+++ b/src/pages/books/_components/Filter.tsx
@@ -2,7 +2,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FiPlus } from 'react-icons/fi';
-import { MdKeyboardArrowDown } from 'react-icons/md';
+
 import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import filtergrayIcon from '../../../assets/filtergray.svg';
@@ -81,7 +81,7 @@ export default function Filter() {
               className="bg-primary flex items-center gap-2 text-white px-4 py-2 rounded-lg font-poppins text-sm font-medium"
               onClick={() => {
                 if (userInformation.id) {
-                  navigate(`/profile/user-profile/${userInformation.id}`);
+                  navigate('/profile/add-book');
                 } else {
                   dispatch(setLoginModalOpen(true));
                 }
@@ -107,7 +107,6 @@ export default function Filter() {
               className="border border-platinum bg-white flex items-center gap-2 text-blackOlive px-4 py-2 rounded-lg font-poppins text-sm font-medium"
             >
               <Image src={sortByIcon} alt="sort" /> {t('books.sort')}
-              <MdKeyboardArrowDown />
             </Button>
           </div>
         </div>

--- a/src/pages/profile/components/ProfileDashboard.tsx
+++ b/src/pages/profile/components/ProfileDashboard.tsx
@@ -53,7 +53,6 @@ export default function ProfileDashboard() {
     {
       label: t('profile.bookmarked'),
       content: <BookmarkedBooks />,
-      hideOnMobile: true,
       permission: false,
       count: bookmarkedCount,
     },

--- a/src/pages/profile/components/ProfileDashboard.tsx
+++ b/src/pages/profile/components/ProfileDashboard.tsx
@@ -111,8 +111,7 @@ export default function ProfileDashboard() {
                           ? 'bg-primary text-white'
                           : 'text-grayDark border border-grayDark'
                       }
-                      ${tab.hideOnLg ? 'lg:hidden' : ''}
-                      ${tab.hideOnMobile ? 'lg:flex hidden' : ''}`}
+                      ${tab.hideOnLg ? 'lg:hidden' : ''}`}
                     >
                       {tab.label}
                       {!tab.hideCount && (


### PR DESCRIPTION
## Summary
- **Add Book button** on homepage desktop filter bar now navigates to `/profile/add-book` instead of the user profile page
- **Bookmarked tab** on the profile page is now visible on mobile (was hidden with `hideOnMobile: true`)
- **Sort button** arrow icon (`MdKeyboardArrowDown`) removed from the homepage filter bar

## Test plan
- [x] Filter tests pass (5/5)
- [x] ProfileDashboard tests pass (5/5)
- [ ] Verify add book button on desktop homepage navigates to add book form
- [ ] Verify bookmarked tab shows on mobile profile view
- [ ] Verify sort button has no dropdown arrow