### PR TITLE
Fix: remove admin platform token from frontend

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,4 @@ VITE_API_URL=https://api.kirjaswappi.fi/api/v1
 VITE_NOTIFICATION_WS_URL=wss://ans.kirjaswappi.fi/ws
 VITE_NOTIFICATION_API_KEY=<Notification_Service_API_Key>
 VITE_SECRET_KEY=YOUR_SECRET_KEY
-VITE_USERNAME=<KirjaSwappi_System_User>
-VITE_PASSWORD=<KirjaSwappi_System_User_Password>
 VITE_GOOGLE_CLIENT_ID=<Google_Client_ID>

--- a/.env.test
+++ b/.env.test
@@ -2,6 +2,4 @@ VITE_API_URL=http://localhost:8080/api/v1
 VITE_NOTIFICATION_WS_URL=ws://localhost:8080/ws
 VITE_NOTIFICATION_API_KEY=test-api-key
 VITE_SECRET_KEY=test-secret-key
-VITE_USERNAME=test-user
-VITE_PASSWORD=test-password
 VITE_GOOGLE_CLIENT_ID=test-google-client-id

--- a/src/hooks/useChatWS.ts
+++ b/src/hooks/useChatWS.ts
@@ -197,8 +197,7 @@ export const useChatWS = (): UseChatWSReturn => {
     }
 
     try {
-      const userToken = getCookie('userToken');
-      const jwtToken = userToken || getCookie('jwtToken');
+      const jwtToken = getCookie('userToken');
       if (!jwtToken) return;
 
       // SockJS does not support custom headers on the HTTP transport.
@@ -223,7 +222,6 @@ export const useChatWS = (): UseChatWSReturn => {
         heartbeatOutgoing: 4000,
         connectHeaders: {
           Authorization: `Bearer ${jwtToken}`,
-          ...(userToken ? {} : { userId: userId as string }),
         },
         debug: (str) => {
           if (import.meta.env.DEV) {

--- a/src/redux/api/apiSlice.ts
+++ b/src/redux/api/apiSlice.ts
@@ -1,73 +1,6 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 import { getCookie, isCookieExpired, setCookie } from '../../utility/cookies';
 
-// =========== Platform (Admin) Token ===========
-let isAuthenticating = false;
-let pendingAuthPromise: Promise<string | null> | null = null;
-
-const fetchToken = async () => {
-  const data = JSON.stringify({
-    username: `${import.meta.env.VITE_USERNAME}`,
-    password: `${import.meta.env.VITE_PASSWORD}`,
-  });
-  const response = await fetch(`${import.meta.env.VITE_API_URL}/authenticate`, {
-    method: 'POST',
-    body: data,
-    headers: { 'Content-Type': 'application/json' },
-  });
-  if (!response.ok) {
-    throw new Error(`Authentication failed with status ${response.status}`);
-  }
-  const { jwtToken, refreshToken } = await response.json();
-  setCookie('jwtToken', jwtToken, 200);
-  setCookie('refreshToken', refreshToken, 100);
-  return jwtToken;
-};
-
-const refreshAuthToken = async () => {
-  const refreshToken = getCookie('refreshToken');
-  if (!refreshToken || isCookieExpired('refreshToken')) {
-    return fetchToken();
-  }
-
-  const response = await fetch(`${import.meta.env.VITE_API_URL}/authenticate/refresh`, {
-    method: 'POST',
-    body: JSON.stringify({ refreshToken }),
-    headers: { 'Content-Type': 'application/json' },
-  });
-  if (!response.ok) {
-    return fetchToken();
-  }
-  const data = await response.json();
-
-  setCookie('jwtToken', data.jwtToken, 100);
-  return data.jwtToken;
-};
-
-const getPlatformToken = async () => {
-  let token = getCookie('jwtToken');
-
-  if (!token || isCookieExpired('jwtToken')) {
-    if (!isAuthenticating) {
-      isAuthenticating = true;
-      pendingAuthPromise = (async () => {
-        try {
-          return token ? await refreshAuthToken() : await fetchToken();
-        } catch (error) {
-          console.error('Authentication error:', error);
-          return null;
-        } finally {
-          isAuthenticating = false;
-          pendingAuthPromise = null;
-        }
-      })();
-    }
-    token = await pendingAuthPromise;
-  }
-
-  return token;
-};
-
 // =========== User Token ===========
 const refreshUserToken = async () => {
   const userRefreshToken = getCookie('userRefreshToken');
@@ -98,42 +31,15 @@ const getUserToken = async (): Promise<string | null> => {
   return token;
 };
 
-// Endpoints that require user auth (must not fall back to platform token)
-const USER_ONLY_ENDPOINTS = [
-  'getInbox',
-  'getInboxByStatus',
-  'getChatMessages',
-  'sendChatMessage',
-  'markChatAsRead',
-  'updateSwapRequestStatus',
-  'addFavouriteBook',
-  'removeFavouriteBook',
-  'changePassword',
-];
-
 export const api = createApi({
   reducerPath: 'api',
   baseQuery: fetchBaseQuery({
     baseUrl: import.meta.env.VITE_API_URL,
-    prepareHeaders: async (headers, { endpoint }) => {
-      if (endpoint === 'authenticate') return headers;
-
-      // Try user token first (for user-facing endpoints)
+    prepareHeaders: async (headers) => {
       const userToken = await getUserToken();
       if (userToken) {
         headers.set('Authorization', `Bearer ${userToken}`);
-        return headers;
       }
-
-      // Don't fall back to platform token for user-scoped endpoints
-      if (USER_ONLY_ENDPOINTS.includes(endpoint)) {
-        return headers;
-      }
-
-      // Fall back to platform token
-      const token = await getPlatformToken();
-      if (token) headers.set('Authorization', `Bearer ${token}`);
-
       return headers;
     },
   }),


### PR DESCRIPTION
## Summary
- Remove `VITE_USERNAME` and `VITE_PASSWORD` env vars (admin credentials were embedded in client-side JS bundle)
- Remove entire platform token flow: `fetchToken()`, `refreshAuthToken()`, `getPlatformToken()`, `USER_ONLY_ENDPOINTS`
- `prepareHeaders` now only attaches user token when available — public endpoints work without any token

**Companion PR:** KirjaSwappi/kirjaswappi-backend#335 (permits public GET endpoints)

## Test plan
- [x] All 1378 frontend tests pass
- [ ] Verify anonymous browsing works (books page loads without login)
- [ ] Verify login + authenticated features (create book, swap, chat) still work